### PR TITLE
fix:using enough X's for mktemp in Darwin

### DIFF
--- a/tools/gsocket
+++ b/tools/gsocket
@@ -99,7 +99,7 @@ command -v "$1" >/dev/null 2>&1 || { echo >&2 "gsocket: command not found: ${1}"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	# OSX does not allow LD_PRELOAD of binaries in /usr/. Copy to tmp...
-	ROOTDIR=$(mktemp -d -t thc-gs)
+	ROOTDIR=$(mktemp -d -t thc-gs.XXXXX)
 	PROGBIN_FULLPATH=$(which "$1")
 
 	[[ -z "$PROGBIN_FULLPATH" ]] && { echo >&2 "gsocket: command not found: ${1}"; exit 1; }


### PR DESCRIPTION
We must use enough X's in the template for create a temporary file with mktemp. Otherwise, the variable `$ROOTDIR` will return empty, and the line 131 will fail

**Pls, review locally or with tests!** I'm using _mktemp (GNU coreutils) 8.32_ and IDK if this will work for other options

<img width="572" alt="image" src="https://user-images.githubusercontent.com/24386288/158050537-67a413c2-1a01-4aa0-9466-d342662a9f52.png">
