### PR TITLE
Segmentation fault printing SERVER_CHECK_SEC in debug mode

### DIFF
--- a/tools/4_gs-netcat.c
+++ b/tools/4_gs-netcat.c
@@ -1540,12 +1540,14 @@ my_getopt(int argc, char *argv[])
 	}
 
 	ptr = GS_getenv("_GSOCKET_SERVER_CHECK_SEC");
-	if (ptr != NULL)
+	if (ptr != NULL) {
 		gopt.gs_server_check_sec = atoi(ptr);
+		DEBUGF_G("_GSOCKET_SERVER_CHECK_SEC=%s (%d)\n", ptr, atoi(ptr));
+	}
 
 	if (gopt.gs_server_check_sec > 0)
 	{
-		DEBUGF_G("SERVER_CHECK_SEC=%s (%d)\n", ptr, atoi(ptr));
+		DEBUGF_G("SERVER_CHECK_SEC=%d\n", gopt.gs_server_check_sec);
 		alarm(gopt.gs_server_check_sec);
 		signal(SIGALRM, cb_sigalarm);
 	}


### PR DESCRIPTION
In debug mode possible segmentation fault printing SERVER_CHECK_SEC.

Reproduce:
1. ./configure --enable-debug && make
2. tools/gs-netcat -t -s TestSecret
3. Fault:
`DEBUG    0 my_getopt:1548 zsh: segmentation fault  tools/gs-netcat -t -s TestSecret`

Reason: if _GSOCKET_SERVER_CHECK_SEC is not set ptr is NULL and later atoi causes segfault

Fix: split debug output in two parts:
1. If _GSOCKET_SERVER_CHECK_SEC is set (i.e. ptr !=NULL) print ptr and atoi(ptr) like before
2. Print final gs_server_check_sec value