### PR TITLE
Fix for missing be64toh/htobe64 on macOS

### DIFF
--- a/tools/common.h
+++ b/tools/common.h
@@ -120,6 +120,12 @@
 #   define ntohll(x) ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((uint64_t)(x) >> 32)
 #  endif
 # endif
+#elif defined(__APPLE__)
+# if !defined(be64toh)
+#  include <libkern/OSByteOrder.h>
+#  define be64toh(v) OSSwapBigToHostInt64(v)
+#  define htobe64(v) OSSwapHostToBigInt64(v)
+# endif
 #endif
 
 #ifndef htonll


### PR DESCRIPTION
`be64toh`/`htobe64` may not be defined on macOS. Worse still, compiler may not even error out, but just issue a warning about undefined function.
Fix that.